### PR TITLE
Fix handling of unsigned arithmetic.

### DIFF
--- a/src/main/java/com/github/emboss/siphash/SipHash.java
+++ b/src/main/java/com/github/emboss/siphash/SipHash.java
@@ -14,32 +14,32 @@ public class SipHash {
             m = UnsignedInt64.binToIntOffset(data, i * 8);
             s.processBlock(m);
         }
-        
+
         m = lastBlock(data, iter);
         s.processBlock(m);
         s.finish();
         return s.digest();
     }
-    
+
     private static long lastBlock(byte[] data, int iter) {
-        long last = ((long) data.length) << 56;
+        long last = (((long) data.length) & 0xff) << 56;
         int off = iter * 8;
 
         switch (data.length % 8) {
             case 7: 
-                last |= ((long) data[off + 6]) << 48;
+                last |= (((long) data[off + 6]) & 0xff) << 48;
             case 6:
-                last |= ((long) data[off + 5]) << 40;
+                last |= (((long) data[off + 5]) & 0xff) << 40;
             case 5:
-                last |= ((long) data[off + 4]) << 32;
+                last |= (((long) data[off + 4]) & 0xff) << 32;
             case 4:
-                last |= ((long) data[off + 3]) << 24;
+                last |= (((long) data[off + 3]) & 0xff) << 24;
             case 3:
-                last |= ((long) data[off + 2]) << 16;
+                last |= (((long) data[off + 2]) & 0xff) << 16;
             case 2:
-                last |= ((long) data[off + 1]) << 8;
+                last |= (((long) data[off + 1]) & 0xff) << 8;
             case 1:
-                last |= (long) data[off];
+                last |= ((long) data[off]) & 0xff;
                 break;
             case 0:
                 break;

--- a/src/main/java/com/github/emboss/siphash/SipHash.java
+++ b/src/main/java/com/github/emboss/siphash/SipHash.java
@@ -22,7 +22,7 @@ public class SipHash {
     }
 
     private static long lastBlock(byte[] data, int iter) {
-        long last = (((long) data.length) & 0xff) << 56;
+        long last = ((long) data.length) << 56;
         int off = iter * 8;
 
         switch (data.length % 8) {

--- a/src/main/java/com/github/emboss/siphash/SipHash.java
+++ b/src/main/java/com/github/emboss/siphash/SipHash.java
@@ -14,13 +14,13 @@ public class SipHash {
             m = UnsignedInt64.binToIntOffset(data, i * 8);
             s.processBlock(m);
         }
-
+        
         m = lastBlock(data, iter);
         s.processBlock(m);
         s.finish();
         return s.digest();
     }
-
+    
     private static long lastBlock(byte[] data, int iter) {
         long last = ((long) data.length) << 56;
         int off = iter * 8;

--- a/src/main/java/com/github/emboss/siphash/UnsignedInt64.java
+++ b/src/main/java/com/github/emboss/siphash/UnsignedInt64.java
@@ -12,14 +12,14 @@ class UnsignedInt64 {
     }
     
     public static long binToIntOffset(byte[] b, int off) {
-        return ((long) b[off    ])       |
-               ((long) b[off + 1]) << 8  |
-               ((long) b[off + 2]) << 16 |
-               ((long) b[off + 3]) << 24 |
-               ((long) b[off + 4]) << 32 |
-               ((long) b[off + 5]) << 40 |
-               ((long) b[off + 6]) << 48 |
-               ((long) b[off + 7]) << 56;
+        return (((long) b[off    ]) & 0xff)     |
+               (((long) b[off + 1]) & 0xff) << 8  |
+               (((long) b[off + 2]) & 0xff) << 16 |
+               (((long) b[off + 3]) & 0xff) << 24 |
+               (((long) b[off + 4]) & 0xff) << 32 |
+               (((long) b[off + 5]) & 0xff) << 40 |
+               (((long) b[off + 6]) & 0xff) << 48 |
+               (((long) b[off + 7]) & 0xff) << 56;
     }
     
     public static void intToBin(long l, byte[] b) {


### PR DESCRIPTION
The existing implementation unfortunately falls prey to Java signed byte arithmetic in a couple of places. The hash of almost any odd-length buffer involving trailing 0xff bytes, for example, will not match the SipHash reference C implementation. This problem also makes it easy to generate collisions.

This pull request applies the typical Java unsigned-math workaround where necessary. The output now matches the reference implementation in my testing.

Apologies for the couple of accidental whitespace changes.
